### PR TITLE
Simple Makefile for pushing releases

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 FROM centos:centos7
 MAINTAINER ome-devel@lists.openmicroscopy.org.uk
+LABEL org.openmicroscopy.release-date="unknown"
 
 RUN mkdir /opt/setup
 WORKDIR /opt/setup

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,13 @@
+#
+# Usage:
+#
+#   make VERSION=5.x.y
+#   git push origin 5.x.y (or to snoopy for review)
+#
+release:
+ifndef VERSION
+	$(error VERSION is undefined)
+endif
+	sed -i -e 's/OMERO_VERSION=latest/OMERO_VERSION=$(VERSION)/' Dockerfile
+	git commit -a -m "Bump version to $(VERSION)"
+	git tag -s -m "Bump version to $(VERSION)" $(VERSION)

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,30 @@
 #
 # Usage:
 #
-#   make VERSION=5.x.y
-#   git push origin 5.x.y (or to snoopy for review)
+#   make VERSION=x.y.z
+#   git push origin x.y.z (or to snoopy for review)
 #
+# To trigger another build, use:
+#
+#   make VERSION=x.y.z BUILD=b
+#   git push origin x.y.z-b (or to snoopy for review)
+#
+
+RELEASE = $(shell date)
+
 release:
+
 ifndef VERSION
 	$(error VERSION is undefined)
 endif
-	sed -i -e 's/OMERO_VERSION=latest/OMERO_VERSION=$(VERSION)/' Dockerfile
-	git commit -a -m "Bump version to $(VERSION)"
-	git tag -s -m "Bump version to $(VERSION)" $(VERSION)
+
+	perl -i -pe 's/OMERO_VERSION=(\S+)/OMERO_VERSION=$(VERSION)/' Dockerfile
+	perl -i -pe 's/(org.openmicroscopy.release-date=)"([^"]+)"/$$1"$(RELEASE)"/' Dockerfile
+
+ifndef BUILD
+	git commit -a -m "Bump OMERO_VERSION to $(VERSION)"
+	git tag -s -m "Tag version $(VERSION)" $(VERSION)
+else
+	git commit -a -m "Re-build $(BUILD) of OMERO_VERSION $(VERSION)"
+	git tag -s -m "Re-tag $(VERSION) with suffix $(BUILD)" $(VERSION)-$(BUILD)
+endif


### PR DESCRIPTION
The intent is that for every OMERO version which should be
made available from hub.docker.com, a new commit/tag pair
will be created and pushed to the organization. If a new
build of a tag is needed, a suffix should be added, e.g.
5.3.3 --> 5.3.3-1