### PR TITLE
Fix doc link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ This example uses the default `postgres` system database for convenience, in pra
 Configuration variables
 -----------------------
 
-All [OMERO configuration properties](www.openmicroscopy.org/site/support/omero/sysadmins/config.html) can be set be defining environment variables `CONFIG_omero_property_name=`.
+All [OMERO configuration properties](https://docs.openmicroscopy.org/latest/omero/sysadmins/config.html) can be set be defining environment variables `CONFIG_omero_property_name=`.
 Since `.` is not allowed in a variable name `.` must be replaced by `_`, and `_` by `__`, for example
 
     -e CONFIG_omero_web_public_enabled=false


### PR DESCRIPTION
As part of clean up for https://trello.com/c/oxWdJSKf/610-clean-up-remaining-links-to-site-support-old-docs-urls although this one was actually broken