### PR TITLE
Use OCI labels

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM centos:centos7
 MAINTAINER ome-devel@lists.openmicroscopy.org.uk
 LABEL org.opencontainers.image.created="unknown"
 LABEL org.opencontainers.image.revision="unknown"
+LABEL org.opencontainers.image.source="https://github.com/openmicroscopy/omero-server-docker"
 
 RUN mkdir /opt/setup
 WORKDIR /opt/setup

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM centos:centos7
-MAINTAINER ome-devel@lists.openmicroscopy.org.uk
+LABEL maintainer="ome-devel@lists.openmicroscopy.org.uk"
 LABEL org.opencontainers.image.created="unknown"
 LABEL org.opencontainers.image.revision="unknown"
 LABEL org.opencontainers.image.source="https://github.com/openmicroscopy/omero-server-docker"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM centos:centos7
 MAINTAINER ome-devel@lists.openmicroscopy.org.uk
-LABEL org.openmicroscopy.release-date="unknown"
-LABEL org.openmicroscopy.commit="unknown"
+LABEL org.opencontainers.image.created="unknown"
+LABEL org.opencontainers.image.revision="unknown"
 
 RUN mkdir /opt/setup
 WORKDIR /opt/setup

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-RELEASE = $(shell date)
+RELEASE = $(shell date -u +%Y-%m-%dT%H:%M:%SZ)
 COMMIT = $(shell git rev-parse HEAD || echo -n NOTGIT)
 
 SHELL = bash
@@ -29,8 +29,8 @@ ifndef VERSION
 endif
 
 	perl -i -pe 's/OMERO_VERSION=(\S+)/OMERO_VERSION=$(VERSION)/' Dockerfile
-	perl -i -pe 's/(org.openmicroscopy.release-date=)"([^"]+)"/$$1"$(RELEASE)"/' Dockerfile
-	perl -i -pe 's/(org.openmicroscopy.commit=)"([^"]+)"/$$1"$(COMMIT)"/' Dockerfile
+	perl -i -pe 's/(org.opencontainers.image.created=)"([^"]+)"/$$1"$(RELEASE)"/' Dockerfile
+	perl -i -pe 's/(org.opencontainers.image.revision=)"([^"]+)"/$$1"$(COMMIT)"/' Dockerfile
 
 ifndef BUILD
 	git commit -a -m "Bump OMERO_VERSION to $(VERSION)"


### PR DESCRIPTION
- Use [Open Container Initiative standard metadata labels](https://github.com/opencontainers/image-spec/blob/master/annotations.md#pre-defined-annotation-keys).
- Also replaces the [deprecated Docker MAINTAINER](https://docs.docker.com/engine/reference/builder/#maintainer-deprecated)